### PR TITLE
Cleanup some legacy plugin code

### DIFF
--- a/grails-app/conf/plugin.yml
+++ b/grails-app/conf/plugin.yml
@@ -2,3 +2,6 @@ grails:
     plugins:
         twitterbootstrap:
             fixtaglib: true
+
+headerAndFooter:
+    baseURL: https://www.ala.org.au/commonui-bs3

--- a/src/main/groovy/au/org/ala/bootstrap3/AlaBootstrap3GrailsPlugin.groovy
+++ b/src/main/groovy/au/org/ala/bootstrap3/AlaBootstrap3GrailsPlugin.groovy
@@ -61,24 +61,9 @@ Brief summary/description of the plugin.
     }
 
     void onConfigChange(Map<String, Object> event) {
-        addDefaultConfig()
     }
 
     void onShutdown(Map<String, Object> event) {
         // TODO Implement code that is executed when the application shuts down (optional)
-    }
-
-    // add default value for config.headerAndFooter.baseURL that can be overridden by client app
-    private void addDefaultConfig() {
-        def value = "https://www.ala.org.au/commonui-bs3"
-        def buildProps = new Properties()
-        buildProps.setProperty("headerAndFooter.baseURL", value)
-        def configSlurper = new ConfigSlurper().parse(buildProps)
-        applicationContext.environment.propertySources.addLast(new MapPropertySource('ala-bootstrap3-default', configSlurper))
-
-        //if config is already initialised, add default value if it is missing
-        if (Holders?.config && !Holders.config.headerAndFooter.baseURL) {
-            Holders.config.headerAndFooter.baseURL = value
-        }
     }
 }

--- a/src/test/groovy/au/org/ala/bootstrap3/HeaderFooterTagLibSpec.groovy
+++ b/src/test/groovy/au/org/ala/bootstrap3/HeaderFooterTagLibSpec.groovy
@@ -14,35 +14,19 @@ import java.security.Principal
 @TestFor(HeaderFooterTagLib)
 class HeaderFooterTagLibSpec extends Specification {
 
-    def originalAlaBaseURL
-    def originalSecurityCasLoginUrl
-    def originalSecurityCasLogoutUrl
-    def originalGrailsServerURL
-
     def setup() {
-        originalAlaBaseURL = grailsApplication.config.ala.baseURL
-        grailsApplication.config.ala.baseURL = 'https://example.com/base-url'
-
-        originalSecurityCasLoginUrl = grailsApplication.config.security.cas.loginUrl
-        grailsApplication.config.security.cas.loginUrl = 'https://example.com/cas/login'
-
-        originalSecurityCasLogoutUrl = grailsApplication.config.security.cas.logoutUrl
-        grailsApplication.config.security.cas.logoutUrl = 'https://example.com/cas/logout'
-
-        originalGrailsServerURL = grailsApplication.config.grails.serverURL
-        grailsApplication.config.grails.serverURL = 'https://example.com/grailsserverurl'
-
         tagLib.tagLinkService = new TagLinkService()
+        tagLib.tagLinkService.alaBaseURL = 'https://example.com/base-url'
+        tagLib.tagLinkService.casLoginUrl = 'https://example.com/cas/login'
+        tagLib.tagLinkService.casLogoutUrl = 'https://example.com/cas/logout'
+        tagLib.tagLinkService.grailServerURL = 'https://example.com/grailsserverurl'
+
         tagLib.tagLinkService.codecLookup = new DefaultCodecLookup()
         tagLib.tagLinkService.codecLookup.setGrailsApplication(grailsApplication)
         tagLib.tagLinkService.codecLookup.reInitialize()
     }
 
     def cleanup() {
-        grailsApplication.config.ala.baseURL = originalAlaBaseURL
-        grailsApplication.config.security.cas.loginUrl = originalSecurityCasLoginUrl
-        grailsApplication.config.security.cas.logoutUrl = originalSecurityCasLogoutUrl
-        grailsApplication.config.grails.serverURL = originalGrailsServerURL
     }
 
     void "test banner content already retrieved"() {

--- a/src/test/groovy/au/org/ala/bootstrap3/TagLinkServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/bootstrap3/TagLinkServiceSpec.groovy
@@ -1,7 +1,13 @@
 package au.org.ala.bootstrap3
 
 import grails.test.mixin.TestFor
+import org.springframework.http.HttpMethod
+import org.springframework.mock.web.MockServletContext
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import spock.lang.Specification
+
+import javax.servlet.http.HttpServletRequest
 
 /**
  * See the API for {@link grails.test.mixin.services.ServiceUnitTestMixin} for usage instructions.
@@ -11,7 +17,12 @@ import spock.lang.Specification
 @TestFor(TagLinkService)
 class TagLinkServiceSpec extends Specification {
 
+    String logoutRequestUri
+    HttpServletRequest logoutRequest
     def setup() {
+        def servletContext = new MockServletContext()
+        logoutRequestUri = service.grailServerURL+'/some/path/with/params?test&foo=bar'
+        logoutRequest = MockMvcRequestBuilders.request(HttpMethod.GET, logoutRequestUri).buildRequest(servletContext)
     }
 
     def cleanup() {
@@ -23,5 +34,78 @@ class TagLinkServiceSpec extends Specification {
 
         then:
         service.hfCache.every { it.value.content == '' }
+    }
+
+    void "test build default logout URL with no additional parameters"() {
+        setup:
+
+        expect:
+        service.buildLogoutUrl(logoutRequest) == "${service.grailServerURL}/"
+    }
+
+    void "test build logout URL using a defined logout URL"() {
+        setup:
+        def request = new MockHttpServletRequestBuilder(HttpMethod.GET, 'http://example.com').buildRequest(new MockServletContext())
+        def logoutUrlBase = service.grailServerURL + '/logout'
+
+        expect:
+        service.buildLogoutUrl(request, null, logoutUrlBase, null) == "${service.grailServerURL}/logout"
+    }
+
+    void "test build logout URL excludes CAS logout URL by default"() {
+        setup:
+        def logoutUrlBase = service.grailServerURL + '/logout'
+        def casLogoutUrl = service.casLogoutUrl
+
+        expect:
+        service.buildLogoutUrl(logoutRequest, casLogoutUrl, logoutUrlBase, null) == "${service.grailServerURL}/logout"
+    }
+
+    void "test build logout URL includes CAS logout URL included if requested"() {
+        setup:
+        def logoutUrlBase = service.grailServerURL + '/logout'
+        def casLogoutUrl = service.casLogoutUrl
+        service.includeLogoutCasUrlParam = true
+
+        expect:
+        service.buildLogoutUrl(logoutRequest, casLogoutUrl, logoutUrlBase, null) == "${service.grailServerURL}/logout?casUrl=${casLogoutUrl}"
+
+        cleanup:
+        service.includeLogoutCasUrlParam = false
+    }
+
+    void "test build logout URL excludes Default App return URL by default"() {
+        setup:
+        def logoutUrlBase = service.grailServerURL + '/logout'
+        def casLogoutUrl = service.casLogoutUrl
+
+        expect:
+        service.buildLogoutUrl(logoutRequest, casLogoutUrl, logoutUrlBase, null) == "${service.grailServerURL}/logout"
+    }
+
+    void "test build logout URL includes Default App return URL if requested"() {
+        setup:
+        def logoutUrlBase = service.grailServerURL + '/logout'
+        def casLogoutUrl = service.casLogoutUrl
+        service.includeLogoutDefaultAppUrlParam = true
+
+        def encodedLogoutRequestUri = 'https://bie.ala.org.au/some/path/with/params?test%26foo%3Dbar'
+
+        expect:
+        service.buildLogoutUrl(logoutRequest, casLogoutUrl, logoutUrlBase, null) == "${service.grailServerURL}/logout?appUrl=$encodedLogoutRequestUri"
+
+        cleanup:
+        service.includeLogoutDefaultAppUrlParam = false
+    }
+
+    void "test build logout URL includes Custom App return URL"() {
+        setup:
+        def logoutUrlBase = service.grailServerURL + '/logout'
+        def casLogoutUrl = service.casLogoutUrl
+        def returnUrl = "http://example.com/bye"
+
+        expect:
+        service.buildLogoutUrl(logoutRequest, casLogoutUrl, logoutUrlBase, returnUrl) == "${service.grailServerURL}/logout?appUrl=$returnUrl"
+
     }
 }


### PR DESCRIPTION
Cleans up some old / ugly code:
 - Move addDefaultConfig from onConfigChanged plugin callback to plugin's default config YAML file
 - Replace getConfigValue method with Grails/Spring Boot builtin
 - Remove casUrl from logout links by default as ALA Auth plugin no longer accepts it
 - Ensure hfCache is thread safe